### PR TITLE
[ update ] Bump Agda to 2.6.2.1

### DIFF
--- a/agda-language-server.cabal
+++ b/agda-language-server.cabal
@@ -63,7 +63,7 @@ library
       OverloadedStrings
   ghc-options: -Wincomplete-patterns -Wunused-do-bind -Wunused-foralls -Wwarnings-deprecations -Wwrong-do-bind -Wmissing-fields -Wmissing-methods -Wmissing-pattern-synonym-signatures -Wmissing-signatures -Werror=incomplete-patterns -fno-warn-orphans
   build-depends:
-      Agda ==2.6.2
+      Agda ==2.6.2.1
     , aeson
     , base >=4.7 && <5
     , bytestring
@@ -86,7 +86,7 @@ executable als
       app
   ghc-options: -Wincomplete-patterns -Wunused-do-bind -Wunused-foralls -Wwarnings-deprecations -Wwrong-do-bind -Wmissing-fields -Wmissing-methods -Wmissing-pattern-synonym-signatures -Wmissing-signatures -threaded -rtsopts -with-rtsopts=-N -Werror=incomplete-patterns -fno-warn-orphans
   build-depends:
-      Agda ==2.6.2
+      Agda ==2.6.2.1
     , aeson
     , agda-language-server
     , base >=4.7 && <5
@@ -141,7 +141,7 @@ test-suite als-test
       OverloadedStrings
   ghc-options: -Wincomplete-patterns -Wunused-do-bind -Wunused-foralls -Wwarnings-deprecations -Wwrong-do-bind -Wmissing-fields -Wmissing-methods -Wmissing-pattern-synonym-signatures -Wmissing-signatures -threaded -rtsopts -with-rtsopts=-N -Werror=incomplete-patterns -fno-warn-orphans
   build-depends:
-      Agda ==2.6.2
+      Agda ==2.6.2.1
     , aeson
     , base >=4.7 && <5
     , bytestring

--- a/package.yaml
+++ b/package.yaml
@@ -23,7 +23,7 @@ description:         Please see the README on GitHub at <https://github.com/bana
 
 dependencies:
   - base >= 4.7 && < 5
-  - Agda == 2.6.2
+  - Agda == 2.6.2.1
   - aeson
   - bytestring
   - containers

--- a/src/Agda/Convert.hs
+++ b/src/Agda/Convert.hs
@@ -129,8 +129,8 @@ fromHighlightingInfo h remove method modFile =
     indirect = liftIO $ writeToTempFile (BS8.unpack (JSON.encode info))
 
 fromDisplayInfo :: DisplayInfo -> TCM IR.DisplayInfo
-fromDisplayInfo info = case info of
-  Info_CompilationOk ws -> do
+fromDisplayInfo = \case 
+  Info_CompilationOk _ ws -> do
     -- filter
     let filteredWarnings = filterTCWarnings (tcWarnings ws)
     let filteredErrors = filterTCWarnings (nonFatalErrors ws)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-18.5
+resolver: lts-18.24
 # Allow a newer minor version of GHC than the snapshot specifies
 compiler-check: match-exact
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -3,85 +3,85 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages:
-- completed:
-    hackage: lexer-applicative-2.1.0.2@sha256:44f71ecb10a50838a5cfd254bc0ede46bb9dcd32897da378c54c43e513229663,1427
-    pantry-tree:
-      size: 389
-      sha256: a880d699c16aac75ce5db249f03aeee1aa6a61adcf290efc51166c19b932cd3e
-  original:
-    hackage: lexer-applicative-2.1.0.2
-- completed:
-    size: 152752
-    subdir: lsp
-    url: https://github.com/haskell/lsp/archive/dce30c9d345f63921cf9cf5045e1dcd753e4fe34.tar.gz
-    name: lsp
-    version: 1.2.0.1
-    sha256: db3371a2cfe5d74f421cc5e8be58d65d680883e78ffc7ef395a55d0e7ba3e588
-    pantry-tree:
-      size: 1417
-      sha256: 702fd234b87a032dbed7dbedefab77bf19aa510fb594ebbfc65f6ec184c31f73
-  original:
-    subdir: lsp
-    url: https://github.com/haskell/lsp/archive/dce30c9d345f63921cf9cf5045e1dcd753e4fe34.tar.gz
-- completed:
-    size: 152752
-    subdir: lsp-types
-    url: https://github.com/haskell/lsp/archive/dce30c9d345f63921cf9cf5045e1dcd753e4fe34.tar.gz
-    name: lsp-types
-    version: 1.3.0.0
-    sha256: db3371a2cfe5d74f421cc5e8be58d65d680883e78ffc7ef395a55d0e7ba3e588
-    pantry-tree:
-      size: 4146
-      sha256: 1ba25c9631a23de4b88da3d4a94cc660f0633e174cb02dc65515d6a5011af93d
-  original:
-    subdir: lsp-types
-    url: https://github.com/haskell/lsp/archive/dce30c9d345f63921cf9cf5045e1dcd753e4fe34.tar.gz
-- completed:
-    hackage: dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657
-    pantry-tree:
-      size: 551
-      sha256: 5defa30010904d2ad05a036f3eaf83793506717c93cbeb599f40db1a3632cfc5
-  original:
-    hackage: dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657
-- completed:
-    hackage: dependent-sum-0.7.1.0@sha256:0e419237f5b86da3659772afff9cab355c0f8d5b3fdb15a5b30e673d8dc83941,2147
-    pantry-tree:
-      size: 290
-      sha256: 009601e5d33e835c7a384e240c5c6ad12643bce9c54b2a0b07201daee3380e51
-  original:
-    hackage: dependent-sum-0.7.1.0@sha256:0e419237f5b86da3659772afff9cab355c0f8d5b3fdb15a5b30e673d8dc83941,2147
-- completed:
-    hackage: dependent-sum-template-0.1.0.3@sha256:0bbbacdfbd3abf2a15aaf0cf2c27e5bdd159b519441fec39e1e6f2f54424adde,1682
-    pantry-tree:
-      size: 436
-      sha256: 32eeadeb991a290a1da41ce7e995dee7d38ebba3bd3e53ea8074c32c086701fd
-  original:
-    hackage: dependent-sum-template-0.1.0.3@sha256:0bbbacdfbd3abf2a15aaf0cf2c27e5bdd159b519441fec39e1e6f2f54424adde,1682
-- completed:
-    hackage: unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
-    pantry-tree:
-      size: 328
-      sha256: e81c5a1e82ec2cd68cbbbec9cd60567363abe02257fa1370a906f6754b6818b8
-  original:
-    hackage: unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
-- completed:
-    hackage: constraints-extras-0.3.1.0@sha256:12016ebb91ad5ed2c82bf7e48c6bd6947d164d33c9dca5ac3965de1bb6c780c0,1777
-    pantry-tree:
-      size: 595
-      sha256: 5fe01617233b7f66ba0e2aef95b218a19225a22e4193a8ed93999a3b7c43a4f3
-  original:
-    hackage: constraints-extras-0.3.1.0@sha256:12016ebb91ad5ed2c82bf7e48c6bd6947d164d33c9dca5ac3965de1bb6c780c0,1777
-- completed:
-    hackage: constraints-0.12@sha256:71c7999d7fa01d8941f08d37d4c107c6b1bcbd0306e234157557b9b096b7f1be,2217
-    pantry-tree:
-      size: 867
-      sha256: 40bb55ad831b213078b79f54bb09c5a2200433dc2a495814444593fb00112834
-  original:
-    hackage: constraints-0.12@sha256:71c7999d7fa01d8941f08d37d4c107c6b1bcbd0306e234157557b9b096b7f1be,2217
 snapshots:
-- completed:
-    size: 585817
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/5.yaml
-    sha256: 22d24d0dacad9c1450b9a174c28d203f9bb482a2a8da9710a2f2a9f4afee2887
-  original: lts-18.5
+- original: lts-18.24
+  completed:
+    sha256: 06d844ba51e49907bd29cb58b4a5f86ee7587a4cd7e6cf395eeec16cba619ce8
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/24.yaml
+    size: 587821
+packages:
+- original:
+    hackage: lexer-applicative-2.1.0.2
+  completed:
+    pantry-tree:
+      sha256: a880d699c16aac75ce5db249f03aeee1aa6a61adcf290efc51166c19b932cd3e
+      size: 389
+    hackage: lexer-applicative-2.1.0.2@sha256:44f71ecb10a50838a5cfd254bc0ede46bb9dcd32897da378c54c43e513229663,1427
+- original:
+    subdir: lsp
+    url: https://github.com/haskell/lsp/archive/dce30c9d345f63921cf9cf5045e1dcd753e4fe34.tar.gz
+  completed:
+    pantry-tree:
+      sha256: 702fd234b87a032dbed7dbedefab77bf19aa510fb594ebbfc65f6ec184c31f73
+      size: 1417
+    subdir: lsp
+    version: 1.2.0.1
+    name: lsp
+    sha256: db3371a2cfe5d74f421cc5e8be58d65d680883e78ffc7ef395a55d0e7ba3e588
+    url: https://github.com/haskell/lsp/archive/dce30c9d345f63921cf9cf5045e1dcd753e4fe34.tar.gz
+    size: 152752
+- original:
+    subdir: lsp-types
+    url: https://github.com/haskell/lsp/archive/dce30c9d345f63921cf9cf5045e1dcd753e4fe34.tar.gz
+  completed:
+    pantry-tree:
+      sha256: 1ba25c9631a23de4b88da3d4a94cc660f0633e174cb02dc65515d6a5011af93d
+      size: 4146
+    subdir: lsp-types
+    version: 1.3.0.0
+    name: lsp-types
+    sha256: db3371a2cfe5d74f421cc5e8be58d65d680883e78ffc7ef395a55d0e7ba3e588
+    url: https://github.com/haskell/lsp/archive/dce30c9d345f63921cf9cf5045e1dcd753e4fe34.tar.gz
+    size: 152752
+- original:
+    hackage: dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657
+  completed:
+    pantry-tree:
+      sha256: 5defa30010904d2ad05a036f3eaf83793506717c93cbeb599f40db1a3632cfc5
+      size: 551
+    hackage: dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657
+- original:
+    hackage: dependent-sum-0.7.1.0@sha256:0e419237f5b86da3659772afff9cab355c0f8d5b3fdb15a5b30e673d8dc83941,2147
+  completed:
+    pantry-tree:
+      sha256: 009601e5d33e835c7a384e240c5c6ad12643bce9c54b2a0b07201daee3380e51
+      size: 290
+    hackage: dependent-sum-0.7.1.0@sha256:0e419237f5b86da3659772afff9cab355c0f8d5b3fdb15a5b30e673d8dc83941,2147
+- original:
+    hackage: dependent-sum-template-0.1.0.3@sha256:0bbbacdfbd3abf2a15aaf0cf2c27e5bdd159b519441fec39e1e6f2f54424adde,1682
+  completed:
+    pantry-tree:
+      sha256: 32eeadeb991a290a1da41ce7e995dee7d38ebba3bd3e53ea8074c32c086701fd
+      size: 436
+    hackage: dependent-sum-template-0.1.0.3@sha256:0bbbacdfbd3abf2a15aaf0cf2c27e5bdd159b519441fec39e1e6f2f54424adde,1682
+- original:
+    hackage: unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
+  completed:
+    pantry-tree:
+      sha256: e81c5a1e82ec2cd68cbbbec9cd60567363abe02257fa1370a906f6754b6818b8
+      size: 328
+    hackage: unliftio-core-0.2.0.1@sha256:9b3e44ea9aacacbfc35b3b54015af450091916ac3618a41868ebf6546977659a,1082
+- original:
+    hackage: constraints-extras-0.3.1.0@sha256:12016ebb91ad5ed2c82bf7e48c6bd6947d164d33c9dca5ac3965de1bb6c780c0,1777
+  completed:
+    pantry-tree:
+      sha256: 5fe01617233b7f66ba0e2aef95b218a19225a22e4193a8ed93999a3b7c43a4f3
+      size: 595
+    hackage: constraints-extras-0.3.1.0@sha256:12016ebb91ad5ed2c82bf7e48c6bd6947d164d33c9dca5ac3965de1bb6c780c0,1777
+- original:
+    hackage: constraints-0.12@sha256:71c7999d7fa01d8941f08d37d4c107c6b1bcbd0306e234157557b9b096b7f1be,2217
+  completed:
+    pantry-tree:
+      sha256: 40bb55ad831b213078b79f54bb09c5a2200433dc2a495814444593fb00112834
+      size: 867
+    hackage: constraints-0.12@sha256:71c7999d7fa01d8941f08d37d4c107c6b1bcbd0306e234157557b9b096b7f1be,2217


### PR DESCRIPTION
The compilation response `Agda.Interaction.Response.Info_CompilationOk` returns an extra argument for the backend being used in `2.6.2.1`. Otherwise, everything seems compatible with `2.6.2`.