### PR TITLE
Use recent text-icu to allow build on Mac M1

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -15,6 +15,7 @@ packages:
 - .
 
 extra-deps:
+  - text-icu-0.8.0.1
   # LSP
   - lexer-applicative-2.1.0.2
   - github: haskell/lsp


### PR DESCRIPTION
Recent text-icu version allows build on Mac M1 by accounting for new Homebrew paths.